### PR TITLE
Add a toggle for tests in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.4)
 project(mockaron)
 
-enable_testing()
+if (NOT MOCKARON_NOTEST)
+  enable_testing()
+endif()
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -17,4 +19,6 @@ add_library(mockaron STATIC
 )
 target_include_directories(mockaron PUBLIC include)
 
-add_subdirectory(test)
+if (NOT MOCKARON_NOTEST)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
For the tests to be disabled, `MOCKARON_NOTEST` has to be defined and set to a non-zero value (i.e.: `MOCKARON_NOTEST=0` enables testing).

This causes `ctest` to fail if tests are disabled.