### PR TITLE
Add hackish template support.

### DIFF
--- a/include/mockaron/mockaron.hpp
+++ b/include/mockaron/mockaron.hpp
@@ -83,6 +83,7 @@
 #define MOCKARON_HOOK0(...)
 #define MOCKARON_HOOK_SIG(...)
 #define MOCKARON_HOOK_SIG0(...)
+#define MOCKARON_HOOK_TEMPLATE(...)
 #define MOCKARON_FUNCTION_HOOK(...)
 #define MOCKARON_FUNCTION_HOOK0(...)
 #else
@@ -119,6 +120,13 @@
     return ::mockaron::detail::run_hook<sig>(                           \
         *reinterpret_cast<::mockaron::detail::mock_impl* const*>(this), \
         #func exp);                                                     \
+  } while (0)
+
+#define MOCKARON_HOOK_TEMPLATE(cl, func, mock, ...)            \
+  do                                                           \
+  {                                                            \
+    if (::mockaron::detail::is_a_mock(this))                   \
+      return reinterpret_cast<mock*>(this)->func(__VA_ARGS__); \
   } while (0)
 
 /** Hook a function with mockaron

--- a/test/mymock.hpp
+++ b/test/mymock.hpp
@@ -52,6 +52,12 @@ struct MyMock : public mockaron::mock_impl
     return no;
   }
 
+  template <typename T>
+  int t(T v)
+  {
+    return 2 * v;
+  }
+
   int z{0};
   My::NoCopy no;
 };

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,7 +2,19 @@
 #include <cstring>
 #include <iostream>
 
+#if MOCKARON_DISABLE_HOOKS
 #include "mymock.hpp"
+#else
+#define MYCLASS_IS_MOCKED
+#include "mymock.hpp"
+
+template <typename T>
+int My::t(T v)
+{
+  MOCKARON_HOOK_TEMPLATE(My, t, MyMock, v);
+  return this->t_(v);
+}
+#endif
 
 int testnohook()
 {
@@ -18,6 +30,8 @@ int testnohook()
   CHECK(mock.get().h(2) == 8);
   CHECK(mock.get().i() == 0);
   CHECK(mock.get_mock_impl().z == 0);
+  CHECK(mock.get().t(4) == 12);
+  CHECK(mock.get().t(3.0) == 9);
 
   {
     MOCKARON_SET_FUNCTION_IMPL(My::l, [](int i, char) {
@@ -58,6 +72,8 @@ int test()
   mock.get().j();
   CHECK(&mock.get().k() == &mock.get_mock_impl().no);
   CHECK(mock.get_mock_impl().z == 42);
+  CHECK(mock.get().t(4) == 8);
+  CHECK(mock.get().t(3.0) == 6);
 
   CHECK(real.f(4) == 16);
 

--- a/test/testlib.hpp
+++ b/test/testlib.hpp
@@ -28,9 +28,26 @@ public:
   static int n(int xx);
   static float n(float xx);
 
+  template <typename T>
+  int t(T v);
+
 private:
+  template <typename T>
+  int t_(T v)
+  {
+    return 3 * v;
+  }
+
   int _i;
   NoCopy _no;
 };
+
+#ifndef MYCLASS_IS_MOCKED
+template <typename T>
+int My::t(T v)
+{
+  return this->t_(v);
+}
+#endif
 
 #endif


### PR DESCRIPTION
There is currently no way of mocking template method. I'm not really proud of this workaround and wish you can find a way of improving it.

The general idea is to be able to hook multiple template instances to a single implementation (through casting or creating temporaries, it can often be achieved). My particular usecase is the one of callbacks. My method takes a callback as parameter, and I don't want to pay the price of instanciating a `std::function` for that. For testing purposes however, I can hook all of my template instances so they call a `std::function` implementation.

Basically, it's exactly the same macro as `MOCKARON_HOOK_SIG` but we don't check the signature.

Let us consider a method `f` of a class `C`.

In `MOCKARON_HOOK_SIG_`, you check that `&C::f` can be `static_cast`ed to whatever the signature is (`detail::add_class_ptr_t<cl, sig>`). We however cannot do that for template methods. We should write `&C::f<T>` with `T` the appropriate type. 

In a first attempt, I added the template parameters so that we can find the address of the method. This changes the name of the hook, however, and we no longer are able to run it.

In a second attempt, I included the `typeid` of the template parameters in the hook name. It might work in some particular situations, but it is difficult to make it work with lambdas. The implementation has to retrieve the `typeid` of the lambda. 

This is my third attempt, which appears to work. The problem here is that it is very unsafe, there is no typechecking at all. I failed to find a way of having this both to work and to be at least a little safe.

This would be a very nice addition to the library, and since you're more resourceful than I am, and know the library better than I do, I hope you can find a better way of doing so. In the meantime, this appears to work.